### PR TITLE
Fixed missing requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,32 +10,41 @@ FROM jupyter/base-notebook:814ef10d64fb
 # NOTE: git is already available in the jupyter/minimal-notebook image.
 USER root
 RUN apt-get update && apt-get install --yes --no-install-recommends \
-    git
-USER $NB_USER
-
-RUN pip install nbgitpuller && \
-    jupyter serverextension enable --py nbgitpuller --sys-prefix
-
-# Uncomment the line below to make nbgitpuller default to start up in JupyterLab
-#ENV NBGITPULLER_APP=lab
-
-# conda/pip/apt install additional packages here, if desired.
-USER root
-RUN apt-get -y --allow-unauthenticated install vim build-essential wget gfortran bison libibverbs-dev libibmad-dev libibumad-dev librdmacm-dev graphviz gcc make
+    git \
+    vim \
+    build-essential \
+    wget \
+    gfortran \
+    bison \
+    libibverbs-dev \
+    libibmad-dev \
+    libibumad-dev \
+    librdmacm-dev \
+    graphviz \
+    gcc \
+    make
+RUN rm -rf /var/lib/apt/lists/*
 
 ADD requirements.txt /tmp/requirements.txt
-
 ADD tutorial_files.py /srv/tutorial_files.py
-
-RUN wget https://downloads.globus.org/globus-connect-personal/linux/stable/globusconnectpersonal-latest.tgz -O /tmp/globusconnectpersonal-latest.tgz
-
-RUN tar -xzvf /tmp/globusconnectpersonal-latest.tgz -C /opt
-RUN mv $(find /opt -type 'd' -name 'globus*' -maxdepth 1) /opt/gcp
-
+ADD gcp_config_additions.py /srv/gcp_config_additions.py
 ADD setup-gcp.py /srv/setup-gcp.py
 ADD start-gcp.sh /srv/start-gcp.sh
 RUN chmod +x /srv/start-gcp.sh
-ADD gcp_config_additions.py /srv/gcp_config_additions.py
+
+# Run these as user
+USER $NB_USER
+
+# Install python packages
+RUN pip install nbgitpuller && \
+    jupyter serverextension enable --py nbgitpuller --sys-prefix
+RUN pip install -r /tmp/requirements.txt
+
+# Install GCP
+RUN wget https://downloads.globus.org/globus-connect-personal/linux/stable/globusconnectpersonal-latest.tgz -O /tmp/globusconnectpersonal-latest.tgz
+RUN tar -xzvf /tmp/globusconnectpersonal-latest.tgz -C /opt
+RUN mv $(find /opt -type 'd' -name 'globus*' -maxdepth 1) /opt/gcp
 RUN cat /srv/gcp_config_additions.py >> /etc/jupyter/jupyter_notebook_config.py
 
-RUN rm -rf /var/lib/apt/lists/*
+# Uncomment the line below to make nbgitpuller default to start up in JupyterLab
+#ENV NBGITPULLER_APP=lab


### PR DESCRIPTION
Well, this was a bit of a wild goose chase. Previously, the build worked fine and kubernetes nearly spawned the pod, but then failed due to a python error. I was certain the spawner command was calling into an older version of python (since we just updated the image to a newer version, they must have changed the python version too, right?), but it turned out I accidentally deleted the `pip install -r` command when migrating the Dockerfile. Woops.

The only line we really need is `RUN pip install -r /tmp/requirements.txt`, but I reorganized things to put the installation commands at the top and the run commands at the bottom. Another minor change is ensuring USER is NB_USER at the bottom to ensure the container isn't run as root. 